### PR TITLE
Change logging of file read to INFO instead of WARNING

### DIFF
--- a/json_settings/__init__.py
+++ b/json_settings/__init__.py
@@ -5,7 +5,7 @@ import logging
 import json
 
 def json_patch(path):
-    logging.warn("Attempting to load local settings from %r" %(path,))
+    logging.info("Attempting to load local settings from %r" %(path,))
     try:
         d = json.load(open(path))
     except IOError:


### PR DESCRIPTION
If JSON settings are being loaded before logging is configured, the default logger outputs the warning which causes problems when invoked in situations where "normal" behaviour results in output being logged and recorded as issues.

Changing to INFO means you can still pick up this message by default in debug mode, or in situations where you explicitly configure logging to record this before loading JSON settings.
