### PR TITLE
Remove magic STATIC_ROOT, MEDIA_ROOT and VAR_DIRECTORY overrides

### DIFF
--- a/json_settings/__init__.py
+++ b/json_settings/__init__.py
@@ -1,11 +1,11 @@
-
 import sys
 import os
 import logging
 import json
 
+
 def json_patch(path):
-    logging.info("Attempting to load local settings from %r" %(path,))
+    logging.info("Attempting to load local settings from %r" % (path,))
     try:
         d = json.load(open(path))
     except IOError:
@@ -14,8 +14,9 @@ def json_patch(path):
     except ValueError:
         logging.exception("Unable to parse json settings in %r" % (path,))
         raise SystemExit(-1)
-    for k,v in d.items():
+    for k, v in d.items():
         globals()[k] = v
+
 
 def patch_settings():
     env_settings = os.environ.get('JSON_SETTINGS', None)
@@ -25,15 +26,6 @@ def patch_settings():
         if not os.path.exists(env_settings):
             return
     json_patch(env_settings)
-    if not "VAR_DIRECTORY" in globals():
-        globals()["VAR_DIRECTORY"] = os.path.join(sys.prefix, "var")
-    if not "STATIC_ROOT" in globals():
-        globals()["STATIC_ROOT"] = os.path.join(globals()["VAR_DIRECTORY"],
-                                                "static")
-    if not "MEDIA_ROOT" in globals():
-        globals()["MEDIA_ROOT"] = os.path.join(globals()["VAR_DIRECTORY"],
-                                               "media")
-        
+
 
 patch_settings()
-


### PR DESCRIPTION
Hi,

Please consider merging this pull request to not have the library set magic settings (see issue #1 ).

Please note this would be a breaking change for projects that depend on your automatically set magic variables, so you may want to consider a version update; however I think it is still for the best.

Thanks and kind regards,
Chris